### PR TITLE
Improve compile-eventflow-fragment and compile-liveview fragment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dependency-reduced-pom.xml
 # Other outputs.
 plan.png
 plan.svg
+
+# Other IDE settings/files
+.vscode

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
@@ -8,20 +8,19 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 
-import javax.inject.Inject;
-
 import org.apache.maven.model.Resource;
-import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 
 /**
  * Mojo used to "compile" sources (i.e. copy from source to target).
  */
 abstract class BaseCompileMojo extends BaseMojo {
 
-    @Inject
-    private DefaultMavenResourcesFiltering filtering;
+    @Component
+    private MavenResourcesFiltering filtering;
 
     /**
      * Copies resources from {@code sourceDirectories} to {@code targetDirectories}. The {@code sourceDirectories}

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2023 Cloud Software Group, Inc.
+// All Rights Reserved. Confidential & Proprietary.
+//
+package com.tibco.ep.buildmavenplugin;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenResourcesExecution;
+
+/**
+ * Mojo used to "compile" sources (i.e. copy from source to target).
+ */
+abstract class BaseCompileMojo extends BaseMojo {
+
+    @Inject
+    private DefaultMavenResourcesFiltering filtering;
+
+    /**
+     * Copies resources from {@code sourceDirectories} to {@code targetDirectories}. The {@code sourceDirectories}
+     * should be <i>root</i> directories, like {@code src/main/eventflow}. This ensures that the directory/package
+     * structure is kept when the files are placed in {@code outputDirectory}.
+     * 
+     * @param sourceDirectories directories to copy resources from
+     * @param targetDirectory output directory
+     * @param includes file extension glob patterns to include
+     * @throws MavenFilteringException if filtering fails for any reason
+     */
+    protected final void execute(File[] sourceDirectories, File targetDirectory, String... includes) throws MavenFilteringException {
+        prechecks();
+        final String encoding = project.getProperties().getOrDefault("project.build.sourceEncoding", "").toString();
+        for (File directory : sourceDirectories) {
+            if (directory.exists()) {
+                Resource resource = new Resource();
+                resource.setDirectory(directory.getAbsolutePath());
+                Arrays.stream(includes).forEach(resource::addInclude);
+                final MavenResourcesExecution exec = new MavenResourcesExecution(Collections.singletonList(resource), targetDirectory, encoding,
+                                                                                 Collections.emptyList(), directory, Collections.emptyList());
+                filtering.filterResources(exec);
+            }
+        }
+    }
+
+}

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseGenerateMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseGenerateMojo.java
@@ -423,7 +423,7 @@ public abstract class BaseGenerateMojo extends BaseMojo {
 
         @Override
         public void onBuildStarted(int nbModules) {
-            getLog().info("Found " + nbModules + " module" + (nbModules > 1 ? "s" : ""));
+            getLog().info("Found " + nbModules + " module" + (nbModules == 1 ? "" : "s"));
         }
 
         @Override


### PR DESCRIPTION
This abstracts the compilation logic for EventFlow and LiveView into a base class, because it is the same functionality. 

In that class, we use MavenResourcesFiltering (i.e. maven-resources-plugin) to copy the files to target/classes instead of doing it manually. This has the benefit of already being setup with BuildContext, meaning it should work better in Studio. I have observed much better reliability on modules being built properly in Studio now. Before, when ep-maven would run, the BuildContext isn't notified, meaning those resources in the workspace are out of date. This would either lead to extra builds or no builds at all.

More info on buildContext and m2e: https://eclipse.dev/m2e/documentation/m2e-making-maven-plugins-compat.html