### PR TITLE
Pre 2.2.1 release.

### DIFF
--- a/.EPDev/build-management/pipelines/tibco-mb/Jenkinsfile
+++ b/.EPDev/build-management/pipelines/tibco-mb/Jenkinsfile
@@ -38,6 +38,16 @@ if (!buildStart) {
     return
 }
 
+def jobUtil = new com.tibco.workflow.JobUtil()
+
+def platform = "linux" // the one platform for which we build.
+
+// Java and Maven versions are still managed more conservatively.
+def labelExpr = jobUtil.getStreamingPlatformLabels(
+    streamingVersion: '11.1', // Streaming version compatiblity version.
+    platform: platform
+)
+
 pipeline {
     options {
         // Only keep a few builds, for up to week.
@@ -75,7 +85,7 @@ pipeline {
     
     agent {
         node {
-            label "(o.rockylinux8 || o.rh8 || o.almalinux8 || o.rh9 || o.almalinux9) && q.str"
+            label labelExpr
         }
     }
 
@@ -106,10 +116,6 @@ pipeline {
         stage ('Build') {
             steps {
                 script {
-                    def jobUtil = new com.tibco.workflow.JobUtil()
-
-                    def platform = "linux" // the one platform for which we build.
-
                     def publicPomFile = "src/ep-maven/pom.xml"
                     
                     epDeclarative.buildInit(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.1
+
+## Removed
+
+- Support for Java code coverage. Cobertura does not work with
+  versions of Java supported by Streaming 10.6 and newer.
+
 ## 2.2.0
 
 ### Added

--- a/ep-maven-interface/src/main/java/com/tibco/ep/sb/services/management/AbstractDestinationBuilder.java
+++ b/ep-maven-interface/src/main/java/com/tibco/ep/sb/services/management/AbstractDestinationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, TIBCO Software Inc.
+ * Copyright © 2020-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -126,6 +126,10 @@ public abstract class AbstractDestinationBuilder extends AbstractBaseBuilder {
         return this;
     }
 
+    /**
+     * Build the destination.
+     * @return a new destination
+     */
     public abstract IDestination build();
 
     @Override

--- a/ep-maven-interface/src/main/java/com/tibco/ep/sb/services/management/IWrappedObject.java
+++ b/ep-maven-interface/src/main/java/com/tibco/ep/sb/services/management/IWrappedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, TIBCO Software Inc.
+ * Copyright © 2020-2024, Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,7 +30,14 @@
 
 package com.tibco.ep.sb.services.management;
 
+/**
+ * Interface for wrappers of objects.
+ */
 public interface IWrappedObject {
 
+    /**
+     * Get the object wrapped by this one.
+     * @return object inside the wrapping
+     */
     Object getWrappedObject();
 }

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -54,6 +54,7 @@
         <oss-stage.skip>true</oss-stage.skip>
         <gpg.skip>${oss-stage.skip}</gpg.skip>
 
+        <ep-maven.version>${project.version}</ep-maven.version>
         <archetype.test.ignoreEOLStyle>true</archetype.test.ignoreEOLStyle>
 
         <!-- Skipping integration tests by default -->
@@ -324,7 +325,7 @@
                     </pomIncludes>
                     <postBuildHookScript>verify</postBuildHookScript>
                     <properties>
-                        <ep-maven.version>${project.version}</ep-maven.version>
+                        <ep-maven.version>${ep-maven.version}</ep-maven.version>
                         <junit.version>${junit.version}</junit.version>
                     </properties>
                     <scriptVariables>

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -338,7 +338,6 @@
                     <execution>
                         <id>integration-test</id>
                         <goals>
-                            <goal>clean</goal>
                             <goal>install</goal>
                             <goal>run</goal>
                         </goals>

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -325,6 +325,7 @@
                     <postBuildHookScript>verify</postBuildHookScript>
                     <properties>
                         <ep-maven.version>${project.version}</ep-maven.version>
+                        <junit.version>${junit.version}</junit.version>
                     </properties>
                     <scriptVariables>
                         <CURRENT_PROJECT_VERSION>${project.version}</CURRENT_PROJECT_VERSION>

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2018, Cloud Software Group, Inc.
+  Copyright (C) 2018-2024. Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -349,12 +349,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>CURRENT_PROJECT_VERSION</name>
-                            <value>${project.version}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <CURRENT_PROJECT_VERSION>${project.version}</CURRENT_PROJECT_VERSION>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -338,6 +338,7 @@
                     <execution>
                         <id>integration-test</id>
                         <goals>
+                            <goal>clean</goal>
                             <goal>install</goal>
                             <goal>run</goal>
                         </goals>

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -323,6 +323,9 @@
                         <pomInclude>*/pom.xml</pomInclude>
                     </pomIncludes>
                     <postBuildHookScript>verify</postBuildHookScript>
+                    <properties>
+                        <ep-maven.version>${project.version}</ep-maven.version>
+                    </properties>
                     <scriptVariables>
                         <CURRENT_PROJECT_VERSION>${project.version}</CURRENT_PROJECT_VERSION>
                     </scriptVariables>

--- a/ep-maven/pom.xml
+++ b/ep-maven/pom.xml
@@ -330,6 +330,7 @@
                     </properties>
                     <scriptVariables>
                         <CURRENT_PROJECT_VERSION>${project.version}</CURRENT_PROJECT_VERSION>
+                        <REGRESSION_REPOSITORY>${settings.localRepository}</REGRESSION_REPOSITORY>
                     </scriptVariables>
                     <settingsFile>src/it/settings.xml</settingsFile>
                     <skipInvocation>${skipIntegrationTests}</skipInvocation>
@@ -351,6 +352,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <CURRENT_PROJECT_VERSION>${project.version}</CURRENT_PROJECT_VERSION>
+                        <REGRESSION_REPOSITORY>${settings.localRepository}</REGRESSION_REPOSITORY>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/ep-maven/src/it/settings.xml
+++ b/ep-maven/src/it/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2020, TIBCO Software Inc.
+  Copyright (C) 2020. Cloud Software Group, Inc.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -48,7 +48,8 @@
             <enabled>true</enabled>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+              <enabled>true</enabled>
+              <updatePolicy>never</updatePolicy>
           </snapshots>
         </repository>
       </repositories>
@@ -60,7 +61,8 @@
             <enabled>true</enabled>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+              <enabled>true</enabled>
+              <updatePolicy>never</updatePolicy>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseMojo.java
@@ -29,40 +29,6 @@
  ******************************************************************************/
 package com.tibco.ep.buildmavenplugin;
 
-import com.tibco.ep.buildmavenplugin.admin.RuntimeCommandRunner;
-import com.tibco.ep.sb.services.RuntimeServices;
-import com.tibco.ep.sb.services.build.IRuntimeBuildService;
-import com.tibco.ep.sb.services.management.AbstractCommandBuilder;
-import com.tibco.ep.sb.services.management.IContext;
-import com.tibco.ep.sb.services.management.IRuntimeAdminService;
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.LegacySupport;
-import org.apache.maven.plugin.MojoExecution;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.internal.DefaultLegacySupport;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectHelper;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.RepositorySystem;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
-import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
-import org.apache.maven.shared.dependency.graph.DependencyNode;
-import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.sonatype.plexus.build.incremental.BuildContext;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -86,6 +52,37 @@ import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.repository.RepositorySystem;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import com.tibco.ep.buildmavenplugin.admin.RuntimeCommandRunner;
+import com.tibco.ep.sb.services.RuntimeServices;
+import com.tibco.ep.sb.services.build.IRuntimeBuildService;
+import com.tibco.ep.sb.services.management.AbstractCommandBuilder;
+import com.tibco.ep.sb.services.management.IContext;
+import com.tibco.ep.sb.services.management.IRuntimeAdminService;
 
 /**
  * Base type

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseTestMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseTestMojo.java
@@ -29,11 +29,23 @@
  ******************************************************************************/
 package com.tibco.ep.buildmavenplugin;
 
-import com.tibco.ep.buildmavenplugin.admin.RuntimeCommandRunner;
-import com.tibco.ep.buildmavenplugin.surefire.Runner;
-import com.tibco.ep.sb.services.management.AbstractDeployFragmentCommandBuilder;
-import com.tibco.ep.sb.services.management.FragmentType;
-import com.tibco.ep.sb.services.management.IDestination;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
@@ -44,30 +56,11 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
+import com.tibco.ep.buildmavenplugin.admin.RuntimeCommandRunner;
+import com.tibco.ep.buildmavenplugin.surefire.Runner;
+import com.tibco.ep.sb.services.management.AbstractDeployFragmentCommandBuilder;
+import com.tibco.ep.sb.services.management.FragmentType;
+import com.tibco.ep.sb.services.management.IDestination;
 
 /**
  * Base test

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseTestMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseTestMojo.java
@@ -549,26 +549,6 @@ abstract class BaseTestMojo extends BaseExecuteMojo {
             String groupId = artifact.getGroupId();
             String artifactId = artifact.getArtifactId();
 
-            // skip provided
-            //
-            if (scope != null && scope.equals(Artifact.SCOPE_PROVIDED)) {
-
-                // cobertura exception
-                //
-                if (artifactId.equals("cobertura") && groupId
-                    .equals("net.sourceforge.cobertura")) {
-                    for (String goal : session.getGoals()) {
-                        if (goal.equals("cobertura:cobertura")) {
-                            return true;
-                        }
-                    }
-                }
-
-                // cobertura not required
-                //
-                return false;
-            }
-
             // skip specific streambase dependencies that are in the runtime
             //
             if (groupId.equals("com.tibco.ep.thirdparty")) {

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/ConfigurationSource.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/ConfigurationSource.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileAttribute;
-import java.util.List;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/InstallProductMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/InstallProductMojo.java
@@ -52,8 +52,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 
 /**
  * <p>Install product zip and tgz artifacts if not already installed.</p>

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
@@ -29,18 +29,17 @@
  ******************************************************************************/
 package com.tibco.ep.buildmavenplugin;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.TEST;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Properties;
+
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.stream.Stream;
-
-import static org.apache.maven.plugins.annotations.LifecyclePhase.TEST;
 
 /**
  * <p>Test a EventFlow fragment using sbunit.</p>

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024, Cloud Software Group, Inc.
+ * Copyright (C) 2018-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -46,10 +46,6 @@ import org.apache.maven.plugins.annotations.Parameter;
  *
  * <p>A java runner for surefire is created and deployed to the test nodes -
  * this runner invokes surefire and hence junit to run the test cases.</p>
- *
- * <p>The java runner sets the system property <b>net.sourceforge.cobertura.datafile</b>
- * to a unique file in the build directory.  So when coverage is enabled, these
- * per-node reports are merged into a single report for processing.</p>
  *
  * <p>The java runner takes the configured reportsDirectory property and
  * appends the node name - the node specific test report files are created in

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestJavaFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestJavaFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2020, TIBCO Software Inc.
+ * Copyright (C) 2018-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -45,10 +45,6 @@ import java.util.Properties;
  *
  * <p>A java runner for surefire is created and deployed to the test nodes -
  * this runner invokes surefire and hence junit to run the test cases.</p>
- *
- * <p>The java runner sets the system property <b>net.sourceforge.cobertura.datafile</b>
- * to a unique file in the build directory.  So when coverage is enabled, these
- * per-node reports are merged into a single report for processing.</p>
  *
  * <p>The java runner takes the configured reportsDirectory property and
  * appends the node name - the node specific test report files are created in

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestLiveViewFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestLiveViewFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2022, TIBCO Software Inc.
+ * Copyright (C) 2018-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -45,10 +45,6 @@ import java.util.Properties;
  *
  * <p>A java runner for surefire is created and deployed to the test nodes -
  * this runner invokes surefire and hence junit to run the test cases.</p>
- *
- * <p>The java runner sets the system property <b>net.sourceforge.cobertura.datafile</b>
- * to a unique file in the build directory.  So when coverage is enabled, these
- * per-node reports are merged into a single report for processing.</p>
  *
  * <p>The java runner takes the configured reportsDirectory property and
  * appends the node name - the node specific test report files are created in

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/UnpackFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/UnpackFragmentMojo.java
@@ -29,6 +29,11 @@
  ******************************************************************************/
 package com.tibco.ep.buildmavenplugin;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_RESOURCES;
+
+import java.io.File;
+
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -36,13 +41,6 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
-
-import static org.apache.maven.plugins.annotations.LifecyclePhase.COMPILE;
-import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_RESOURCES;
-
-import java.io.File;
-
-import org.apache.maven.artifact.Artifact;
 
 /**
  * <p>

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/UnpackNarMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/UnpackNarMojo.java
@@ -29,6 +29,11 @@
  ******************************************************************************/
 package com.tibco.ep.buildmavenplugin;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_RESOURCES;
+
+import java.io.File;
+
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -36,13 +41,6 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
-
-import static org.apache.maven.plugins.annotations.LifecyclePhase.COMPILE;
-import static org.apache.maven.plugins.annotations.LifecyclePhase.PROCESS_RESOURCES;
-
-import java.io.File;
-
-import org.apache.maven.artifact.Artifact;
 
 /**
  * <p>Unpack any nar (native archive) archives listed in dependences.</p>

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/surefire/Runner.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/surefire/Runner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, TIBCO Software Inc.
+ * Copyright (C) 2018-2024. Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -61,16 +61,6 @@ public class Runner
     protected final static String NODE_NAME = "com.kabira.platform.node.name";
     
     /**
-     * cobertura sub directory
-     */
-    protected final static String COBERTURA_DIR = "cobertura";
-    
-    /**
-     * cobertura results file
-     */
-    protected final static String COBERTURA_RESULTS = "cobertura.ser";
-    
-    /**
      * Main method to run a set of unit tests on the node.
      * 
      * @param args
@@ -129,16 +119,6 @@ public class Runner
                     new Object[] { testResultsPort, traceCalls, traceSocketMessages, testFileNames } });
         }
         // ========================================================================================================================
-
-
-        // force coverage to a node-specific file
-        //
-        System.setProperty("net.sourceforge.cobertura.datafile", System.getProperty(REPORTS_DIRECTORY)+File.separator+COBERTURA_DIR+File.separator+System.getProperty(NODE_NAME)+"."+COBERTURA_RESULTS);
-        File reportDirectory = new File(System.getProperty(REPORTS_DIRECTORY)+File.separator+COBERTURA_DIR);
-        if (!reportDirectory.exists()) {
-            // we could run this in locker but it seems safe to just ignore mkdirs if already created
-            reportDirectory.mkdirs();
-        }
 
         if (args.length == 1) {
             // FIX THIS - this shouldn't happen if called correctly from maven

--- a/ep-maven/src/site/markdown/contint_examples.md
+++ b/ep-maven/src/site/markdown/contint_examples.md
@@ -53,17 +53,14 @@ $ mvn -DenvironmentVariables=BUILD_ID=${BUILD_ID} ...
 
 ## Other configurations
 
-1. The source code management has to be defined so that jenkins
-can find the source
+1. The source code management has to be defined so that Jenkins
+can find the source.
 
 2. Suitable build nodes have to be defined
 
-3. Additional maven goals such as site, cobertura and sonar can be defined
+3. Additional Maven goals such as `site` and `sonar` can be defined.
 
-4. Post-build actions to publish [coverage reports](https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin)
-  results are very useful
-
-5. [Email notifications](https://wiki.jenkins-ci.org/display/JENKINS/Email-ext+plugin) 
+4. [Email notifications](https://wiki.jenkins-ci.org/display/JENKINS/Email-ext+plugin) 
 to the development team
 
-6. Centralized [maven settings](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)
+5. Centralized [Maven settings](https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)

--- a/ep-maven/src/site/markdown/general_examples.md
+++ b/ep-maven/src/site/markdown/general_examples.md
@@ -63,10 +63,6 @@ for each dependency.  So :
     cases.  Dependency is not included when compiling application.  Dependency 
     is included in shipped artifacts.
 
-One exception to this rule is cobertura - if set a a provided dependency <<and>>
-cobertura:cobertura goal is being run, then the maven plugin will include
-cobertura on the classpath when testing
-
 <a name="parent-poms"></a>
 
 ## Parent poms
@@ -1247,7 +1243,6 @@ pom.xml is shown below :
         <sonar.projectName>${projectgroupId}.${projectartifactId}</sonar.projectName>
         <sonar.junit.reportsPath>${project.build.directory}/test-reports</sonar.junit.reportsPath>
         <sonar.working.directory>${project.build.directory}${file.separator}sonar</sonar.working.directory>
-        <sonar.cobertura.reportPath>${project.build.directory}/site/cobertura/coverage.xml</sonar.cobertura.reportPath>
     </properties>
 ....
     <build>
@@ -1264,11 +1259,10 @@ pom.xml is shown below :
 ....
 ```
 
-Since SonarQube will process the junit test report, coverage report as well as
+Since SonarQube will process the JUnit test report as well as
 the source files in the tree, a typical run will include :
 
 ``` shell
-$ mvn cobertura:cobertura
 $ mvn site:site
 $ mvn sonar:sonar
 ```

--- a/ep-maven/src/site/markdown/java_examples.md.vm
+++ b/ep-maven/src/site/markdown/java_examples.md.vm
@@ -4,7 +4,7 @@
 * [Basic build, junit test and install](#basic-build-junit-test-and-install)
 * [Adding additional files to the java fragment](#adding-additional-files-to-the-java-fragment)
 * [Java dependencies](#java-dependencies)
-* [Code coverage via cobertura](#code-coverage-via-cobertura)
+* [Code coverage (unsupported)](#code-coverage)
 
 <a name="codeline-structure"></a>
 
@@ -117,116 +117,8 @@ For example the following dependency in a pom.xml :
 Will result in the zip file containing dependencies/java/org.slf4j-slf4j-api-1.7.12.jar.
 Any further transitive dependencies are also added.
 
-<a name="code-coverage-via-cobertura"></a>
+<a name="code-coverage"></a>
 
-## Code coverage via cobertura
+## Code Coverage
 
-Java code coverage is supported using the [cobertura-maven-plugin](http://www.mojohaus.org/cobertura-maven-plugin/) -
-this needs to be configured in both the dependencies and reporting sections of
-the pom.xml :
-  
-``` xml
-...
-    <dependencies>
-        ...
-        <dependency>
-            <groupId>net.sourceforge.cobertura</groupId>
-            <artifactId>cobertura</artifactId>
-            <version>2.1.1</version>
-            <scope>provided</scope>
-        </dependency>
-        ...
-    </dependencies> 
-...
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-            </plugin>
-        </plugins>
-    </reporting>    
-...
-```
-
-An example single node run is shown below :
-  
-``` shell
-$ mvn cobertura:cobertura
-[INFO] Scanning for projects...
-[INFO]                                                                         
-[INFO] ------------------------------------------------------------------------
-[INFO] Building Java Fragment - hello world 3.0.0
-[INFO] ------------------------------------------------------------------------
-[INFO] 
-[INFO] >>> cobertura-maven-plugin:2.7:cobertura (default-cli) > [cobertura]test @ helloworld >>>
-[INFO] 
-[INFO] --- ep-maven-plugin:1.0.0:install-product (default-install-product-1) @ helloworld ---
-[INFO] com.tibco.ep.dtm:platform_osxx86_64:zip:3.0.0:test product is already installed manually
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ helloworld ---
-[INFO] Nothing to compile - all classes are up to date
-[INFO] 
-[INFO] --- cobertura-maven-plugin:2.7:instrument (default-cli) @ helloworld ---
-[INFO] Cobertura 2.1.1 - GNU GPL License (NO WARRANTY) - See COPYRIGHT file
-[INFO] Cobertura: Saved information on 2 classes.
-[INFO] Cobertura: Saved information on 2 classes.
-[INFO] Instrumentation was successful.
-[INFO] NOT adding cobertura ser file to attached artifacts list.
-[INFO] 
-[INFO] --- maven-compiler-plugin:3.3:testCompile (default-testCompile) @ helloworld ---
-[INFO] Nothing to compile - all classes are up to date
-[INFO] 
-[INFO] --- ep-maven-plugin:1.0.0:start-nodes (default-start-nodes) @ helloworld ---
-.... 
-[INFO] --- ep-maven-plugin:1.0.0:test-java-fragment (default-test-java-fragment) @ helloworld ---
-....
-[INFO] Reading node coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/A.helloworld.cobertura.ser
-[INFO] Writing cluster coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/cobertura.ser
-[INFO] Cobertura: Loaded information on 2 classes.
-[INFO] Cobertura: Loaded information on 1 classes.
-[INFO] Cobertura: Saved information on 2 classes.
-[INFO] 
-[INFO] --- ep-maven-plugin:1.0.0:stop-nodes (default-stop-nodes-1) @ helloworld ---
-....
-[INFO] 
-[INFO] --- cobertura-maven-plugin:2.7:cobertura (default-cli) @ helloworld ---
-[INFO] Cobertura 2.1.1 - GNU GPL License (NO WARRANTY) - See COPYRIGHT file
-[INFO] Cobertura: Loaded information on 2 classes.
-Report time: 70ms
-
-[INFO] Cobertura Report generation was successful.
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-[INFO] Total time: 30.646 s
-[INFO] Finished at: 2016-01-20T10:56:17+00:00
-[INFO] Final Memory: 32M/555M
-[INFO] ------------------------------------------------------------------------
-```
-  
-By default a html report is generated in the site directory (by default 
-target/site/cobertura/index.html).
-  
-The maven plugin will merge coverage reports from multiple nodes 
-automatically.  For example :
-  
-``` shell
-$ mvn cobertura:cobertura
-...
-[INFO] Reading node coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/A.helloworld.cobertura.ser
-[INFO] Reading node coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/B.helloworld.cobertura.ser
-[INFO] Reading node coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/C.helloworld.cobertura.ser
-[INFO] Writing cluster coverage report /Users/plord/workspace/dtmexamples/java-fragments/helloworld/target/cobertura/cobertura.ser
-...
-[INFO] <<< cobertura-maven-plugin:2.7:cobertura (default-cli) < [cobertura]test @ helloworld <<<
-[INFO] 
-[INFO] --- cobertura-maven-plugin:2.7:cobertura (default-cli) @ helloworld ---
-[INFO] Cobertura 2.1.1 - GNU GPL License (NO WARRANTY) - See COPYRIGHT file
-[INFO] Cobertura: Loaded information on 2 classes.
-Report time: 73ms
-
-[INFO] Cobertura Report generation was successful.
-....
-```
+Java code coverage is not supported as of version 2.2.1.

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/BetterAbstractMojoTestCase.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/BetterAbstractMojoTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, TIBCO Software Inc.
+ * Copyright © 2018-2024. Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,14 +50,14 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 
-/** Use this as you would {@link AbstractMojoTestCase},
- * where you want more of the standard maven defaults to be set
- * (and where the {@link AbstractMojoTestCase} leaves them as null or empty).
- * This includes:
+/**
+ * Use this as you would {@link AbstractMojoTestCase}, where you want more of the
+ * standard Maven defaults to be set (and where the {@link AbstractMojoTestCase}
+ * leaves them as null or empty). This includes:
  * <ul>
- * <li> local repo, repo sessions and managers configured
- * <li> maven default remote repos installed (NB: this does not use your ~/.m2 local settings)
- * <li> system properties are copies
+ * <li> Local repository, repository sessions and managers configured
+ * <li> Maven default remote repo repositories installed (NB: this does not use your ~/.m2 local settings)
+ * <li> System properties are copies
  * </ul>
  * 
  */ 

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/BetterAbstractMojoTestCase.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/BetterAbstractMojoTestCase.java
@@ -56,31 +56,80 @@ import org.eclipse.aether.repository.LocalRepository;
  * leaves them as null or empty). This includes:
  * <ul>
  * <li> Local repository, repository sessions and managers configured
- * <li> Maven default remote repo repositories installed (NB: this does not use your ~/.m2 local settings)
+ * <li> Maven default remote repositories installed <b>N.B.:</b> this does
+ * not use your {@code ~/.m2} local settings.
  * <li> System properties are copies
  * </ul>
  * 
  */ 
 public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
 
-    File regressionRepository;
+    protected File regressionRepository;
+
+    /**
+     * Get the regression repository, which should hold the other stub and test
+     * artifacts needed for tests.
+     * <p>
+     * Normally, this should be the local repository of the current build. It is OK
+     * to mix test-only artifacts into the local repository because the Maven build
+     * arranges for such artifacts to <b>not</b> be deployed.
+     * <p>
+     * This throws a runtime error if a suitable local repository cannot be
+     * determined.
+     * @return a local repository path
+     */
+    private File findRegressionRepository() {
+        // Can we figure out the current local repository form settings here?
+        // For now, set from the Surefire configuration based on the
+        // surrounding build's current Maven settings.
+        // So this means such tests cannot be run in IDE unless you set
+        // TIBCO_EP_HOME before/around its launcher, and that location is
+        // right for the local repository you intend to use.
+        final String regressionRepositoryFromExternal = System
+                .getProperty("REGRESSION_REPOSITORY");
+        if (null != regressionRepositoryFromExternal) {
+            return new File(regressionRepositoryFromExternal);
+        }
+
+        // Guesses based on older EP conventions
+        final String tibcoEPHome = System.getenv("TIBCO_EP_HOME");
+        if (null != tibcoEPHome) {
+            File regressionRepository = new File(
+                    tibcoEPHome + "/BUILD/repository");
+            if (regressionRepository.exists()) {
+                return regressionRepository;
+            }
+
+            regressionRepository = new File(tibcoEPHome + "/.repository");
+            if (regressionRepository.exists()) {
+                return regressionRepository;
+            }
+        }
+
+        // Error situations fall through to here.
+        throw new RuntimeException(
+                "Cannot determine Maven local repository from REGRESSION_REPOSITORY nor TIBCO_EP_HOME.");
+    }
+
+    /**
+     * Get the version of test-only projects.
+     * <p>
+     * This does <b>not</b> include stub projects.
+     * @return the Maven version of such projects
+     */
+    protected String getTestProjectsVersion() {
+        return "0.0.1-SNAPSHOT";
+    }
     
     protected MavenSession newMavenSession() {
         try {
             MavenExecutionRequest request = new DefaultMavenExecutionRequest();
             MavenExecutionResult result = new DefaultMavenExecutionResult();
-
-            regressionRepository = new File(System.getenv("TIBCO_EP_HOME")+"/BUILD/repository");
-            if (regressionRepository.exists()) {
-                request.setLocalRepositoryPath(regressionRepository);
-            } else {
-                regressionRepository = new File(System.getenv("TIBCO_EP_HOME")+"/.repository");
-                if (regressionRepository.exists()) {
-                    request.setLocalRepositoryPath(regressionRepository);
-                }
-            }
             
-            // populate sensible defaults, including repository basedir and remote repos
+            regressionRepository = findRegressionRepository();
+            request.setLocalRepositoryPath(regressionRepository);
+
+            // Populate sensible defaults, including repository basedir and remote repos
             MavenExecutionRequestPopulator populator;
             populator = getContainer().lookup( MavenExecutionRequestPopulator.class );
             populator.populateDefaults( request );
@@ -88,12 +137,21 @@ public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
             // this is needed to allow java profiles to get resolved; i.e. avoid during project builds:
             // [ERROR] Failed to determine Java version for profile java-1.5-detected @ org.apache.commons:commons-parent:22, /Users/alex/.m2/repository/org/apache/commons/commons-parent/22/commons-parent-22.pom, line 909, column 14
             Properties properties = System.getProperties();
-            properties.put("env.TIBCO_EP_HOME", System.getenv("TIBCO_EP_HOME"));
-            request.setSystemProperties( properties );
+            String tibcoEPHome = System.getenv("TIBCO_EP_HOME");
+            if (null == tibcoEPHome) {
+                throw new RuntimeException("TIBCO_EP_HOME must be set for mojo tests.");
+                // Probably should force in the mojo configurations, since there
+                // is a parameter for the install location, instead of always needed
+                // TIBCO_EP_HOME.
+
+            } else {
+                properties.put("env.TIBCO_EP_HOME", tibcoEPHome);
+                request.setSystemProperties( properties );
+            }
             
-            // and this is needed so that the repo session in the maven session 
-            // has a repo manager, and it points at the local repo
-            // (cf MavenRepositorySystemUtils.newSession() which is what is otherwise done)
+            // And this is needed so that the repo session in the maven session 
+            // has a repository manager, and it points at the local repository.
+            // (cf. MavenRepositorySystemUtils.newSession() which is what is otherwise done)
             DefaultMaven maven = (DefaultMaven) getContainer().lookup( Maven.class );
             DefaultRepositorySystemSession repoSession =
                 (DefaultRepositorySystemSession) maven.newRepositorySession( request );
@@ -107,6 +165,10 @@ public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
                 request, result );
             return session;
         } catch (Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException)e; // we want the best backtrace 
+            }
+            
             throw new RuntimeException(e);
         }
     }

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/NodeLifecycleTest.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/NodeLifecycleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, TIBCO Software Inc.
+ * Copyright © 2018-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -59,7 +59,8 @@ public class NodeLifecycleTest extends BetterAbstractMojoTestCase {
     SimulatedLog simulatedLog = new SimulatedLog(false);
 
     /**
-     * Clean up
+     * Clean up after a test.
+     * @throws Exception on error
      */
     @After
     public void postTest() throws Exception {

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/PackageTest.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/PackageTest.java
@@ -192,8 +192,10 @@ public class PackageTest extends BetterAbstractMojoTestCase {
         packageStreambase.execute();
         assertEquals(simulatedLog.getErrorLog(), 0, simulatedLog.getErrorLog().length());
         assertEquals(simulatedLog.getWarnLog(), 0, simulatedLog.getWarnLog().length());
+        
+        final String eventflowFragmentVersion = getTestProjectsVersion();
         // there is no output to check for this target
-        String eventFlowFragmentZip = "target/projects/eventflow/target/eventflow-" + pomVersion + "-ep-eventflow-fragment.zip";
+        String eventFlowFragmentZip = "target/projects/eventflow/target/eventflow-" + eventflowFragmentVersion + "-ep-eventflow-fragment.zip";
         assertTrue(new File(eventFlowFragmentZip).exists());
         assertTrue(zipContains(eventFlowFragmentZip, "upgrade-plan.txt"));
         assertTrue(zipContains(eventFlowFragmentZip, "engine.conf"));
@@ -204,11 +206,11 @@ public class PackageTest extends BetterAbstractMojoTestCase {
 
         // simulate install
         //
-        File eventflowDestDir = new File(this.regressionRepository, "com/tibco/ep/testmavenplugin/eventflow/" + pomVersion);
+        File eventflowDestDir = new File(this.regressionRepository, "com/tibco/ep/testmavenplugin/eventflow/" + eventflowFragmentVersion);
         eventflowDestDir.mkdirs();
         Files
             .copy(new File(eventFlowFragmentZip)
-                .toPath(), new File(eventflowDestDir, "eventflow-" + pomVersion + ".zip")
+                .toPath(), new File(eventflowDestDir, "eventflow-" + eventflowFragmentVersion + ".zip")
                 .toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         // variation with eventflow deps

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/UnitTest.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/UnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, TIBCO Software Inc.
+ * Copyright (C) 2018-2024. Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -367,8 +367,6 @@ public class UnitTest extends BetterAbstractMojoTestCase {
         } catch (FileAlreadyExistsException e) {
             // ignore
         }
-
-        new File("target/projects/java/target/cobertura").mkdirs();
 
         LOGGER.info("   Start nodes");
         StartNodesMojo startNodes = (StartNodesMojo) lookupConfiguredMojo(startPom, "start-nodes");

--- a/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/UnpackTest.java
+++ b/ep-maven/src/test/java/com/tibco/ep/buildmavenplugin/UnpackTest.java
@@ -30,18 +30,14 @@
 package com.tibco.ep.buildmavenplugin;
 
 import java.io.File;
+
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.plugin.testing.resources.TestResources;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.tibco.ep.buildmavenplugin.InstallProductMojo;
-import com.tibco.ep.buildmavenplugin.UnpackFragmentMojo;
-import com.tibco.ep.buildmavenplugin.UnpackNarMojo;
 
 /**
  * Unpack tests

--- a/ep-maven/src/test/java/com/tibco/ep/sb/services/stubs/build/RuntimeBuildService.java
+++ b/ep-maven/src/test/java/com/tibco/ep/sb/services/stubs/build/RuntimeBuildService.java
@@ -30,17 +30,16 @@
 
 package com.tibco.ep.sb.services.stubs.build;
 
-import com.tibco.ep.sb.services.build.BuildErrorDetails;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
 import com.tibco.ep.sb.services.build.BuildExceptionDetails;
 import com.tibco.ep.sb.services.build.BuildParameters;
 import com.tibco.ep.sb.services.build.BuildResult;
 import com.tibco.ep.sb.services.build.BuildTarget;
 import com.tibco.ep.sb.services.build.IBuildNotifier;
 import com.tibco.ep.sb.services.build.IRuntimeBuildService;
-
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A test {@link IRuntimeBuildService}

--- a/ep-maven/src/test/projects/application/deploy.xml
+++ b/ep-maven/src/test/projects/application/deploy.xml
@@ -50,25 +50,25 @@
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>java</artifactId>
             <type>ep-java-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>sw</artifactId>
             <type>ep-sw-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>liveview</artifactId>
             <type>ep-liveview-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -83,7 +83,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <nodeDeployFile>${project.basedir}/src/test/configurations/node.conf</nodeDeployFile>
                 </configuration>

--- a/ep-maven/src/test/projects/application/deploy.xml
+++ b/ep-maven/src/test/projects/application/deploy.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/application/pom.xml
+++ b/ep-maven/src/test/projects/application/pom.xml
@@ -83,7 +83,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/application/pom.xml
+++ b/ep-maven/src/test/projects/application/pom.xml
@@ -50,25 +50,25 @@
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>java</artifactId>
             <type>ep-java-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>sw</artifactId>
             <type>ep-sw-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>liveview</artifactId>
             <type>ep-liveview-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/ep-maven/src/test/projects/application/pom.xml
+++ b/ep-maven/src/test/projects/application/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/application2/pom.xml
+++ b/ep-maven/src/test/projects/application2/pom.xml
@@ -51,24 +51,18 @@
             <artifactId>java</artifactId>
             <type>ep-java-fragment</type>
             <version>0.0.1-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/../java/target/java-0.0.1-SNAPSHOT-ep-java-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
             <version>0.0.1-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/../eventflow/target/eventflow-0.0.1-SNAPSHOT-ep-eventflow-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>liveview</artifactId>
             <type>ep-liveview-fragment</type>
             <version>0.0.1-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/../liveview/target/liveview-0.0.1-SNAPSHOT-ep-liveview-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/ep-maven/src/test/projects/application2/pom.xml
+++ b/ep-maven/src/test/projects/application2/pom.xml
@@ -83,7 +83,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/application2/pom.xml
+++ b/ep-maven/src/test/projects/application2/pom.xml
@@ -50,25 +50,25 @@
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>java</artifactId>
             <type>ep-java-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/../java/target/java-${project.version}-ep-java-fragment.zip</systemPath>
+            <systemPath>${project.basedir}/../java/target/java-0.0.1-SNAPSHOT-ep-java-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/../eventflow/target/eventflow-${project.version}-ep-eventflow-fragment.zip</systemPath>
+            <systemPath>${project.basedir}/../eventflow/target/eventflow-0.0.1-SNAPSHOT-ep-eventflow-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>liveview</artifactId>
             <type>ep-liveview-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/../liveview/target/liveview-${project.version}-ep-liveview-fragment.zip</systemPath>
+            <systemPath>${project.basedir}/../liveview/target/liveview-0.0.1-SNAPSHOT-ep-liveview-fragment.zip</systemPath>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/ep-maven/src/test/projects/application2/pom.xml
+++ b/ep-maven/src/test/projects/application2/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/application3/pom.xml
+++ b/ep-maven/src/test/projects/application3/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/application3/pom.xml
+++ b/ep-maven/src/test/projects/application3/pom.xml
@@ -60,7 +60,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/eventflow/pom.xml
+++ b/ep-maven/src/test/projects/eventflow/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/eventflow/pom.xml
+++ b/ep-maven/src/test/projects/eventflow/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/eventflow2/pom.xml
+++ b/ep-maven/src/test/projects/eventflow2/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/eventflow2/pom.xml
+++ b/ep-maven/src/test/projects/eventflow2/pom.xml
@@ -50,7 +50,7 @@
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
         

--- a/ep-maven/src/test/projects/eventflow2/pom.xml
+++ b/ep-maven/src/test/projects/eventflow2/pom.xml
@@ -60,7 +60,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/java/deploy.xml
+++ b/ep-maven/src/test/projects/java/deploy.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/java/pom.xml
+++ b/ep-maven/src/test/projects/java/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2018, Cloud Software Group, Inc.
+  Copyright (C) 2018-2024. Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -36,14 +36,8 @@
 
     <groupId>com.tibco.ep.testmavenplugin</groupId>
     <artifactId>java</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>ep-java-fragment</packaging>
-
-    <parent>
-        <groupId>com.tibco.ep.testmavenplugin</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <relativePath>..</relativePath>
-    </parent>  
 
     <organization>
         <name>Cloud Software Group, Inc.</name>
@@ -60,6 +54,7 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
+                <version>${ep-maven.version}</version>
                 <configuration>
                     <mainClass>main</mainClass>
                 </configuration>

--- a/ep-maven/src/test/projects/java/pom.xml
+++ b/ep-maven/src/test/projects/java/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/java/pom.xml
+++ b/ep-maven/src/test/projects/java/pom.xml
@@ -60,7 +60,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <mainClass>main</mainClass>
                 </configuration>

--- a/ep-maven/src/test/projects/java/start.xml
+++ b/ep-maven/src/test/projects/java/start.xml
@@ -41,8 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
-        <relativePath>..</relativePath>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>  
 
     <build>
@@ -51,7 +50,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/java/stop.xml
+++ b/ep-maven/src/test/projects/java/stop.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/java/test.xml
+++ b/ep-maven/src/test/projects/java/test.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2018, Cloud Software Group, Inc.
+  Copyright (C) 2018-2024. Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -41,18 +41,10 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 
-    <dependencies>
-        <dependency>
-            <groupId>net.sourceforge.cobertura</groupId>
-            <artifactId>cobertura</artifactId>
-            <scope>scope</scope>
-            <version>2.1.1</version>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>
@@ -63,7 +55,6 @@
                 <version>${project.version}</version>
                 <configuration>
                     <additionalClasspathElements>
-                        <additionalClasspathElement>../../../../../../../target/generated-classes/cobertura</additionalClasspathElement>
                         <additionalClasspathElement>../../../../../../../target/classes</additionalClasspathElement>
                     </additionalClasspathElements>
                     <nodeOptions>

--- a/ep-maven/src/test/projects/lifecycle/pom.xml
+++ b/ep-maven/src/test/projects/lifecycle/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/lifecycle/pom.xml
+++ b/ep-maven/src/test/projects/lifecycle/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <environmentVariables>
                         <MY_ENVRONMENT>TEST</MY_ENVRONMENT>

--- a/ep-maven/src/test/projects/lifecycle/status.xml
+++ b/ep-maven/src/test/projects/lifecycle/status.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${ep-maven.version}</version>
                 <configuration>
                     <command>display</command>
                     <target>node</target>

--- a/ep-maven/src/test/projects/lifecycle/status2.xml
+++ b/ep-maven/src/test/projects/lifecycle/status2.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/lifecycle/status3.xml
+++ b/ep-maven/src/test/projects/lifecycle/status3.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/lifecycle/stop.xml
+++ b/ep-maven/src/test/projects/lifecycle/stop.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${ep-maven.version}</version>
                 <configuration>
                     <environmentVariables>
                         <MY_ENVRONMENT>TEST</MY_ENVRONMENT>

--- a/ep-maven/src/test/projects/liveview/pom.xml
+++ b/ep-maven/src/test/projects/liveview/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
 
         </plugins>

--- a/ep-maven/src/test/projects/liveview/pom.xml
+++ b/ep-maven/src/test/projects/liveview/pom.xml
@@ -41,7 +41,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -67,6 +67,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <version>${junit.version}</version>
         </dependency>
 
         <!-- build only dependencies - the runtime provides these -->

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -86,8 +86,8 @@
 
     </dependencies>
 
-    <!-- Exercise the plugin. -->
     <build>
+        <!-- Exercise the plugin. -->
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -99,6 +99,21 @@
         </pluginManagement>
 
         <plugins>
+            <!-- Local IT repository list. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it-list-repositories</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>list-repositories</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  Copyright (C) 2018, Cloud Software Group, Inc.
+  Copyright (C) 2018-2024. Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
@@ -99,21 +99,6 @@
         </pluginManagement>
 
         <plugins>
-            <!-- Local IT repository list. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>it-list-repositories</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>list-repositories</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -102,6 +102,7 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
+                <version>${ep-maven.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -43,16 +43,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
             
-    <pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>com.tibco.ep</groupId>
-                <artifactId>ep-maven-plugin</artifactId>
-                <version>${ep-maven.version}</version>
-            </plugin>
-        </plugins>
-    </pluginManagement>
-
     <dependencies>
 
         <!-- compile, test and deploy dependencies -->
@@ -98,6 +88,16 @@
 
     <!-- Exercise the plugin. -->
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.tibco.ep</groupId>
+                    <artifactId>ep-maven-plugin</artifactId>
+                    <version>${ep-maven.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>com.tibco.ep</groupId>

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -38,13 +38,6 @@
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
-    <parent>
-        <groupId>com.tibco.ep</groupId>
-        <artifactId>ep-maven</artifactId>
-        <version>${project.version}</version>
-        <relativePath>../../../..</relativePath>
-    </parent>  
-
     <dependencies>
 
         <!-- compile, test and deploy dependencies -->

--- a/ep-maven/src/test/projects/pom.xml
+++ b/ep-maven/src/test/projects/pom.xml
@@ -36,7 +36,22 @@
 
     <groupId>com.tibco.ep.testmavenplugin</groupId>
     <artifactId>parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+            
+    <pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.tibco.ep</groupId>
+                <artifactId>ep-maven-plugin</artifactId>
+                <version>${ep-maven.version}</version>
+            </plugin>
+        </plugins>
+    </pluginManagement>
 
     <dependencies>
 
@@ -80,17 +95,13 @@
 
     </dependencies>
 
+    <!-- Exercise the plugin. -->
     <build>
         <plugins>
-
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <configuration>
-                </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/ep-maven/src/test/projects/sw/pom.xml
+++ b/ep-maven/src/test/projects/sw/pom.xml
@@ -22,7 +22,7 @@
             <groupId>com.tibco.ep.testmavenplugin</groupId>
             <artifactId>eventflow</artifactId>
             <type>ep-eventflow-fragment</type>
-            <version>${project.version}</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
         

--- a/ep-maven/src/test/projects/sw/pom.xml
+++ b/ep-maven/src/test/projects/sw/pom.xml
@@ -31,7 +31,6 @@
             <plugin>
                 <groupId>com.tibco.ep</groupId>
                 <artifactId>ep-maven-plugin</artifactId>
-                <version>${project.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/ep-maven/src/test/projects/sw/pom.xml
+++ b/ep-maven/src/test/projects/sw/pom.xml
@@ -2,7 +2,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <!-- vim: set tabstop=4 softtabstop=0 expandtab shiftwidth=4 smarttab : -->
-    <!-- Copyright (c) 2019-2023 Cloud Software Group, Inc. All Rights Reserved. Confidential & Proprietary. -->
+    <!-- Copyright (c) 2019-2024 Cloud Software Group, Inc. All Rights Reserved. Confidential & Proprietary. -->
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/ep-maven/src/test/projects/sw/pom.xml
+++ b/ep-maven/src/test/projects/sw/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.tibco.ep.testmavenplugin</groupId>
         <artifactId>parent</artifactId>
-        <version>${project.version}</version>
+        <version>0.0.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- The maven version -->
+        <!-- Targetted Java version. -->
+        <maven.compiler.release>11</maven.compiler.release>
+
+        <!-- The Maven version -->
         <maven-api.version>3.8.8</maven-api.version>
 
-        <!-- only generate docs for maven plugin -->
+        <!-- Only generate docs for maven plugin -->
         <maven.site.skip>true</maven.site.skip>
         <maven.site.deploy.skip>true</maven.site.deploy.skip>
 
@@ -653,7 +656,6 @@
                     <configuration>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
-			<release>11</release>
                     </configuration>
                 </plugin>
 
@@ -918,8 +920,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <sourcetab>4</sourcetab>
+                    <quiet>true</quiet>
                     <additionalJOptions>
                         <additionalJOption>-verbose</additionalJOption>
                         <additionalJOption>-Xdoclint:all</additionalJOption>

--- a/pom.xml
+++ b/pom.xml
@@ -661,6 +661,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.4.1</version>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.4.2</version>
                     <configuration>
                         <archive>
                             <manifestEntries>
@@ -723,7 +723,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
 
                 <plugin>
@@ -1005,10 +1005,7 @@
                 </reportSets>
 
                 <configuration>
-                    <source>11</source>
-                    <sourcetab>4</sourcetab>
                     <additionalJOptions>
-                        <additionalJOption>-verbose</additionalJOption>
                         <additionalJOption>-Xdoclint:all</additionalJOption>
                     </additionalJOptions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                 </property>
             </activation>
             <properties>
-                <unit.test.sb.version>11.0.0-SNAPSHOT</unit.test.sb.version>
+                <unit.test.sb.version>11.0.1-SNAPSHOT</unit.test.sb.version>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -576,19 +576,6 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>net.sourceforge.cobertura</groupId>
-                <artifactId>cobertura</artifactId>
-                <version>2.1.1</version>
-                <!-- tool not part of JDK 10+ -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- required for JDK 10+ -->
             <dependency>
                 <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
* Update plugins.
* Avoid system scope.
* Fixed version for the plugin test projects (0.0.1-SNAPSHOT), not the same as the ep-maven version.
* Drop Cobertura support.