### PR TITLE
Use real default values for parameters instead of helpers

### DIFF
--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseCompileMojo.java
@@ -1,7 +1,32 @@
-//
-// Copyright (c) 2023 Cloud Software Group, Inc.
-// All Rights Reserved. Confidential & Proprietary.
-//
+/*
+ * Copyright (C) 2023-2025 Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.tibco.ep.buildmavenplugin;
 
 import java.io.File;

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseGenerateMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseGenerateMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Cloud Software Group, Inc.
+ * Copyright (C) 2020-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -40,8 +40,6 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -62,7 +60,6 @@ import java.util.stream.Stream;
  */
 public abstract class BaseGenerateMojo extends BaseMojo {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseGenerateMojo.class);
     private static final String COMPILER_PROPERTIES_EQUALS = "=";
     private static final String ENGINE_DATA_AREA = "com.tibco.ep.dtm.engine.data.area";
 
@@ -122,7 +119,7 @@ public abstract class BaseGenerateMojo extends BaseMojo {
      *
      * @since 2.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     /**
@@ -149,7 +146,7 @@ public abstract class BaseGenerateMojo extends BaseMojo {
      *
      * @since 2.0.0
      */
-    @Parameter(required = false, property = "testEventflowDirectories")
+    @Parameter(required = false, property = "testEventflowDirectories", defaultValue = "${project.basedir}/src/test/eventflow")
     File[] testEventflowDirectories;
 
     /**
@@ -252,9 +249,6 @@ public abstract class BaseGenerateMojo extends BaseMojo {
 
         prechecks();
         initializeService(PlatformService.CODE_GENERATION, ErrorHandling.FAIL);
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
-        testEventflowDirectories = getOrDefaultSrcTestEventflow(testEventflowDirectories);
 
         setupEngineDataArea();
 
@@ -411,10 +405,6 @@ public abstract class BaseGenerateMojo extends BaseMojo {
         return Stream.of(files)
             .filter(File::exists)
             .map(File::toPath).collect(Collectors.toList());
-    }
-
-    private List<Path> toPaths(File[] files) {
-        return Stream.of(files).map(File::toPath).collect(Collectors.toList());
     }
 
     private class BuildNotifier implements IBuildNotifier {

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/BaseMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -319,7 +319,7 @@ abstract class BaseMojo extends AbstractMojo {
                 //  Only create a context if we have a service.
                 //
                 try {
-                    context = adminService.newContext(productHome.toPath());
+                    context = adminService.newContext(productHome.getAbsoluteFile().toPath());
                 } catch (IllegalArgumentException e) {
 
                     if (errorHandling == ErrorHandling.IGNORE) {
@@ -806,7 +806,7 @@ abstract class BaseMojo extends AbstractMojo {
         if (productHome == null || productHome.getAbsolutePath().isEmpty()) {
             String epHome = System.getenv("TIBCO_EP_HOME");
             if (epHome != null) {
-                productHome = new File(epHome);
+                productHome = new File(epHome).getAbsoluteFile();
             } else {
 
                 File base = new File(session.getLocalRepository().getBasedir()).getParentFile();
@@ -856,47 +856,6 @@ abstract class BaseMojo extends AbstractMojo {
             return new ArrayList<>();
         }
         return Arrays.asList(array);
-    }
-
-    /**
-     * Use a default directory if the original value is null or empty. Only use the value if the
-     * default directory exists.
-     *
-     * @param originalValue The original value
-     * @param defaultDir    The default directory
-     * @return The array represented by the default value
-     */
-    private File[] initializeAndCheck(File[] originalValue, String defaultDir) {
-
-        if (originalValue == null || originalValue.length == 0) {
-
-            //  Default value, if it exists.
-            //
-            File defaultValue = new File(project.getBasedir(), defaultDir);
-            if (defaultValue.exists() && defaultValue.isDirectory()) {
-                return new File[]{defaultValue};
-            } else {
-                return new File[]{};
-            }
-        }
-
-        return originalValue;
-    }
-
-    /**
-     * @param pomValue The POM value for eventflowDirectories
-     * @return The actual value
-     */
-    File[] getOrDefaultSrcMainEventflow(File[] pomValue) {
-        return initializeAndCheck(pomValue, DEFAULT_SRC_MAIN_EVENTFLOW);
-    }
-
-    /**
-     * @param pomValue The POM value for testEventflowDirectories
-     * @return The actual value
-     */
-    File[] getOrDefaultSrcTestEventflow(File[] pomValue) {
-        return initializeAndCheck(pomValue, DEFAULT_SRC_TEST_EVENTFLOW);
     }
 
     /**

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/CompileEventFlow.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/CompileEventFlow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -70,12 +70,11 @@ public class CompileEventFlow extends BaseCompileMojo {
      * 
      * @since 1.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     @Override
     public void execute() throws MojoExecutionException {
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
         getLog().debug("Compiling EventFlow fragment");
         final File outputDirectory = new File(project.getBuild().getOutputDirectory());
         try {

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/DeployFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/DeployFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -67,7 +67,7 @@ public class DeployFragmentMojo extends BaseTestMojo {
      *
      * @since 1.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     /**
@@ -124,7 +124,6 @@ public class DeployFragmentMojo extends BaseTestMojo {
     public void execute() throws MojoExecutionException {
         getLog().debug("Deploy");
 
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
 
         // determine if we have executions steps in the pom - if so we can skip id this
         // run is a default one

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/PackageEventFlowFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/PackageEventFlowFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2023, Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -90,7 +90,7 @@ public class PackageEventFlowFragmentMojo extends BasePackageMojo {
      *
      * @since 1.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     @Parameter(required = false, property = "skipGenerateSources", defaultValue = "false")
@@ -99,8 +99,6 @@ public class PackageEventFlowFragmentMojo extends BasePackageMojo {
     @Override
     public void execute() throws MojoExecutionException {
         getLog().debug("Creating eventflow fragment");
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
 
         prechecks();
 

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/PackageLiveViewFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/PackageLiveViewFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2023, Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -87,7 +87,7 @@ public class PackageLiveViewFragmentMojo extends BasePackageMojo {
      *
      * @since 1.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     /**
@@ -107,8 +107,6 @@ public class PackageLiveViewFragmentMojo extends BasePackageMojo {
     @Override
     public void execute() throws MojoExecutionException {
         getLog().debug("Creating liveview fragment");
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
 
         prechecks();
 

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/SetResources.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/SetResources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -87,7 +87,7 @@ public class SetResources extends BasePackageMojo {
      * 
      * @since 1.1.0
      */
-    @Parameter( required = false, property = "eventflowDirectories" )
+    @Parameter( required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow" )
     File[] eventflowDirectories;
 
     /**
@@ -110,8 +110,6 @@ public class SetResources extends BasePackageMojo {
         getLog().debug( "Set resources" );
 
         prechecks();
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
 
         if (configurationDirectory.exists()) {
             Resource resource = new Resource();

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestEventFlowFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024. Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -82,7 +82,7 @@ public class TestEventFlowFragmentMojo extends BaseTestMojo {
      *
      * @since 1.0.0
      */
-    @Parameter(required = false, property = "eventflowDirectories")
+    @Parameter(required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow")
     File[] eventflowDirectories;
 
     /**
@@ -119,14 +119,11 @@ public class TestEventFlowFragmentMojo extends BaseTestMojo {
      *
      * @since 2.0.1
      */
-    @Parameter(required = false, property = "testEventflowDirectories")
+    @Parameter(required = false, property = "testEventflowDirectories", defaultValue = "${project.basedir}/src/test/eventflow")
     File[] testEventflowDirectories;
 
     @Override
     public void execute() throws MojoExecutionException {
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
-        testEventflowDirectories = getOrDefaultSrcTestEventflow(testEventflowDirectories);
 
         getLog().debug("Testing eventflow fragment " + Arrays.toString(eventflowDirectories));
 

--- a/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestLiveViewFragmentMojo.java
+++ b/ep-maven/src/main/java/com/tibco/ep/buildmavenplugin/TestLiveViewFragmentMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024. Cloud Software Group, Inc.
+ * Copyright (C) 2018-2025 Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -81,7 +81,7 @@ public class TestLiveViewFragmentMojo extends BaseTestMojo {
      *
      * @since 1.0.0
      */
-    @Parameter( required = false, property = "eventflowDirectories" )
+    @Parameter( required = false, property = "eventflowDirectories", defaultValue = "${project.basedir}/src/main/eventflow" )
     File[] eventflowDirectories;
 
     /**
@@ -126,8 +126,6 @@ public class TestLiveViewFragmentMojo extends BaseTestMojo {
 
     public void execute() throws MojoExecutionException {
         getLog().debug( "Testing live data mart fragment" );
-
-        eventflowDirectories = getOrDefaultSrcMainEventflow(eventflowDirectories);
 
         Properties modelProperties = project.getModel().getProperties();
         boolean testCasesFound = true;


### PR DESCRIPTION
For eventflowDirectories and related properties, we can specify the default values directly in the mojo instead of relying on a helper method to get the default if the user didn't specify anything.

Also changed the productHome to explicitly request the absolute path since I was getting issues on cygwin with unix-like paths.